### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build with Maven
+        run: mvn -f webapp/pom.xml package
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: webapp/src/main/resources/webapp
+          publish_branch: gh-pages
+          force_orphan: true
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ The build will produce `src/main/resources/webapp/js/app.js`. Open `src/main/res
 ## Deployment
 
 The contents of `src/main/resources/webapp` can be pushed to GitHub Pages or any static host to serve the application.
+
+## GitHub Pages Workflow
+
+This repository includes a GitHub Actions workflow at `.github/workflows/deploy.yml`.
+It builds the project using:
+
+```bash
+mvn -f webapp/pom.xml package
+```
+
+After a successful build the workflow deploys `webapp/src/main/resources/webapp`
+to the `gh-pages` branch using `peaceiris/actions-gh-pages`. Pushing to `main`
+will automatically publish the updated static site.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the Maven project and deploy to `gh-pages`
- document the deployment workflow in the README

## Testing
- `mvn -f webapp/pom.xml -q package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c0961a3d88332b43ab86fc4423504